### PR TITLE
gnupg 2.4.9 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gnupg" %}
-{% set version = "2.4.7" %}
+{% set version = "2.4.9" %}
 
 package:
   name: {{ name|lower }}
@@ -7,30 +7,30 @@ package:
 
 source:
   url: https://www.gnupg.org/ftp/gcrypt/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: 7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46
+  sha256: dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964
 
 build:
   number: 0
-  # At minimum, libksba isn't available on s390x
-  skip: true  # [win or s390x]
+  skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('gnupg', max_pin='x.x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
     - pkg-config
   host:
-    - npth 1.8
-    - libgpg-error 1.51
-    - libgcrypt 1.9.3
-    - libksba 1.6.7
-    - libassuan 3.0.1
+    - npth {{ npth }}
+    - libgpg-error {{ libgpg_error }}
+    - libgcrypt {{ libgcrypt }}
+    - libksba {{ libksba }}
+    - libassuan {{ libassuan }}
     - pinentry 1.3.1
     - sqlite {{ sqlite }}
-    - ntbtls 0.3.2
-    - libiconv 1.16
+    - ntbtls {{ ntbtls}}
+    - libiconv {{ libiconv}}
     - readline {{ readline }}
     - zlib {{ zlib }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ requirements:
     - libassuan {{ libassuan }}
     - pinentry 1.3.1
     - sqlite {{ sqlite }}
-    - ntbtls {{ ntbtls}}
-    - libiconv {{ libiconv}}
+    - ntbtls {{ ntbtls }}
+    - libiconv {{ libiconv }}
     - readline {{ readline }}
     - zlib {{ zlib }}
 


### PR DESCRIPTION
gnupg 2.4.9 

**Destination channel:** Defaults

### Links

- [PKG-11938]
- dev_url:        https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git
- conda_forge:    https://github.com/conda-forge/gnupg-feedstock

### Explanation of changes:

- new version number


[PKG-11938]: https://anaconda.atlassian.net/browse/PKG-11938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ