### PR TITLE
gnupg 2.5.18

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 upload_channels:
   - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/pbp/fs/libassuan-feedstock/pr2/cf4b556

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/pbp/fs/libassuan-feedstock/pr2/cf4b556

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* ./build-aux
+
 ./configure \
     --disable-doc \
     --prefix=$PREFIX \
@@ -8,6 +11,7 @@
     --with-libgcrypt-prefix=$PREFIX \
     --with-libksba-prefix=$PREFIX \
     --with-libassuan-prefix=$PREFIX \
+    --with-ntbtls-prefix=$PREFIX \
     --enable-all-tests
 
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-./configure --prefix=$PREFIX --enable-all-tests
+./configure \
+    --disable-doc \
+    --prefix=$PREFIX \
+    --with-npth-prefix=$PREFIX \
+    --with-libgpg-error-prefix=$PREFIX \
+    --with-libgcrypt-prefix=$PREFIX \
+    --with-libksba-prefix=$PREFIX \
+    --with-libassuan-prefix=$PREFIX \
+    --enable-all-tests
+
 make
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "gnupg" %}
-{% set version = "2.4.9" %}
+{% set version = "2.5.18" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://www.gnupg.org/ftp/gcrypt/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964
+  sha256: 0dbd64e0322fe1a4813360d46539d5f8daf4a8fa235cf5fce464e8b0214a7e4f
 
 build:
   number: 0
@@ -37,6 +37,7 @@ requirements:
 test:
   commands:
     - gpg --help
+    - ${CONDA_PREFIX}/libexec/keyboxd --version
 
 about:
   home: https://www.gnupg.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
+    - gnuconfig
     - pkg-config
   host:
     - npth {{ npth }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - libgpg-error {{ libgpg_error }}
     - libgcrypt {{ libgcrypt }}
     - libksba {{ libksba }}
-    - libassuan {{ libassuan }}
+    - libassuan 3.0.2
     - pinentry 1.3.1
     - sqlite {{ sqlite }}
     - ntbtls {{ ntbtls }}


### PR DESCRIPTION
gnupg 2.5.18

**Destination channel:** Snowflake

### Links

- [PKG-13772](https://anaconda.atlassian.net/browse/PKG-13772) 
- [Upstream repository](https://github.com/gpg/gnupg/tree/gnupg-2.5.18)

### Explanation of changes:

- version update to fix CVE
- added all optional flags from the host to the configure.
- disable documentation 
- keyboxd added

[PKG-13772]: https://anaconda.atlassian.net/browse/PKG-13772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ